### PR TITLE
Add environment variable for Bluesky Access Token

### DIFF
--- a/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/BlueskyAnnouncer.java
+++ b/api/jreleaser-model-api/src/main/java/org/jreleaser/model/api/announce/BlueskyAnnouncer.java
@@ -26,6 +26,7 @@ import java.util.List;
  */
 public interface BlueskyAnnouncer extends Announcer {
     String TYPE = "bluesky";
+    String BLUESKY_ACCESS_TOKEN = "BLUESKY_ACCESS_TOKEN";
 
     String getHost();
 

--- a/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/BlueskyAnnouncerValidator.java
+++ b/core/jreleaser-model-impl/src/main/java/org/jreleaser/model/internal/validation/announce/BlueskyAnnouncerValidator.java
@@ -24,6 +24,7 @@ import org.jreleaser.util.Errors;
 
 import java.nio.file.Files;
 
+import static org.jreleaser.model.api.announce.BlueskyAnnouncer.BLUESKY_ACCESS_TOKEN;
 import static org.jreleaser.model.internal.validation.common.Validator.checkProperty;
 import static org.jreleaser.model.internal.validation.common.Validator.resolveActivatable;
 import static org.jreleaser.model.internal.validation.common.Validator.validateTimeout;
@@ -72,7 +73,7 @@ public class BlueskyAnnouncerValidator {
             checkProperty(context,
                 listOf(
                     "announce.bluesky.password",
-                    "bluesky.handle"),
+                    BLUESKY_ACCESS_TOKEN),
                 "announce.bluesky.password",
                 announcer.getPassword(),
                 errors,


### PR DESCRIPTION
Password can now be set using: "BLUESKY_ACCESS_TOKEN" environment variable.

Used the Access Token name. It's a password only for now but a password is a token, but not every token is a password.
